### PR TITLE
Reduce horizontal padding in .footer-container

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -414,7 +414,7 @@ button[type="submit"]:hover {
   gap: 2rem;
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0 10rem;
+  padding: 0 6rem;
 }
 
 .footer-section h3 {


### PR DESCRIPTION
Decreased the horizontal padding of the .footer-container class from 10rem to 6rem to improve layout and spacing.